### PR TITLE
NPE: LoginActivity.initAnlayticsManager()

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -312,6 +312,8 @@ public class LoginActivity extends AccountAuthenticatorActivity
     private void initAnalyticsManager() {
         final UserAccount account = SalesforceSDKManager.getInstance().getUserAccountManager().getCurrentUser();
         final SalesforceAnalyticsManager analyticsManager = SalesforceAnalyticsManager.getInstance(account);
-        analyticsManager.updateLoggingPrefs();
+	if (analyticsManager != null) {
+            analyticsManager.updateLoggingPrefs();
+	}
     }
 }


### PR DESCRIPTION
NullPointerException: SalesforceAnalyticsManager.getInstance(Account).updateLoggingPrefs() called when not logged in.

- LoginActivity doesn’t always finish with an account. User can back out instead, but SalesforceAnalyticsManager.getInstance() can return null when there isn’t any account.

Steps:
1) Start Login Activity
2) Press back without logging in